### PR TITLE
PDB Data Preprocess scripts 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,165 @@
+mmCIF/
+
+inference_outputs/
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+data/data/
+outputs/

--- a/data/pdb_data_loader.py
+++ b/data/pdb_data_loader.py
@@ -88,7 +88,8 @@ class PdbDataset(data.Dataset):
         if filter_conf.min_beta_percent is not None:
             pdb_csv = pdb_csv[
                 pdb_csv.strand_percent > filter_conf.min_beta_percent]
-        if filter_conf.rog_quantile > 0.0:
+        if filter_conf.rog_quantile is not None \
+            and filter_conf.rog_quantile > 0.0:
             prot_rog_low_pass = _rog_quantile_curve(
                 pdb_csv, 
                 filter_conf.rog_quantile,

--- a/data/utils.py
+++ b/data/utils.py
@@ -23,7 +23,7 @@ import torch
 Protein = protein.Protein
 
 # Global map from chain characters to integers.
-ALPHANUMERIC = string.ascii_letters + string.digits
+ALPHANUMERIC = string.ascii_letters + string.digits + ' '
 CHAIN_TO_INT = {
     chain_char: i for i, chain_char in enumerate(ALPHANUMERIC)
 }

--- a/eval_outputs/.gitignore
+++ b/eval_outputs/.gitignore
@@ -1,0 +1,1 @@
+baseline


### PR DESCRIPTION
Hi Yim,
I would like to contribute to one of your TODO, namely `Set-up easily downloadable training data.` 
To complete this task, we need to write a PDB data preprocessing script, since your original script only supports .mmcif format. 
Based on your existing script `data/process_pdb_files.py`, I further implement a few features so that this script does the same things as  `data/process_pdb_dataset.py`, where it only deals with .mmcif files. Now, with the updated `data/process_pdb_files.py`, we can build protein structure datasets from raw pdb format files. Using pdb files has many advantages. For example, many cleaned protein datasets are based on pdb format like CATH.  I am also trying to reproduce the training using CATH data. I would like to see if using small but high-quality protein structure data can reproduce similar results as the se3 diffusion. Based on OpenFold's finding that using a small portion of structures can achieve competitive performance as AF2, I am confident about se3 diffusion. : ) 
I will open the training details, logs, and evaluation results. stay tuned!

You can review the commit history to see the details I made. 

Best,
Zhangzhi