### PR TITLE
add DDP support,main change:1.add get_ddp_info() in Experiment class.…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,16 @@ cython_debug/
 #.idea/
 data/data/
 outputs/
+
+#PDB processed dataset
+data/processed_pdb/
+data/processed_pdb_openfold/
+
+#PDBBind dataset
+DiffusionProteinLigand/data/PDBBind*
+
+#pynb for debug code
+pynb/
+
+#slurm_output for record
+slurm_output/

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -69,11 +69,14 @@ experiment:
   name: baseline
   run_id: null
 
+  #training mode
+  use_ddp : False
+
   # Training arguments
   log_freq: 1000
   batch_size: 128
   eval_batch_size: ${data.samples_per_eval_length}
-  num_loader_workers: 10
+  num_loader_workers: 5
   num_epoch: 95
   learning_rate: 0.0001
   max_squared_res: 300000

--- a/data/pdb_data_loader.py
+++ b/data/pdb_data_loader.py
@@ -1,4 +1,10 @@
 """PDB dataset loader."""
+import math
+from typing import TypeVar, Optional, Iterator
+
+import torch
+import torch.distributed as dist
+
 import tree
 import numpy as np
 import torch
@@ -122,8 +128,8 @@ class PdbDataset(data.Dataset):
             self.csv = eval_csv
             self._log.info(
                 f'Validation: {len(self.csv)} examples with lengths {eval_lengths}')
-
-    @fn.lru_cache(maxsize=50000)
+    # cache make the same sample in same batch 
+    @fn.lru_cache(maxsize=100)
     def _process_csv_row(self, processed_file_path):
         processed_feats = du.read_pkl(processed_file_path)
         processed_feats = du.parse_chain_feats(processed_feats)
@@ -315,3 +321,144 @@ class TrainSampler(data.Sampler):
 
     def __len__(self):
         return len(self._dataset_indices) * self._batch_size
+
+
+# modified from torch.utils.data.distributed.DistributedSampler
+# key points: shuffle of each __iter__ is determined by epoch num to ensure the same shuffle result for each proccessor
+class DistributedTrainSampler(data.Sampler):
+    r"""Sampler that restricts data loading to a subset of the dataset.
+
+    modified from torch.utils.data.distributed import DistributedSampler
+
+    .. note::
+        Dataset is assumed to be of constant size and that any instance of it always
+        returns the same elements in the same order.
+
+    Args:
+        dataset: Dataset used for sampling.
+        num_replicas (int, optional): Number of processes participating in
+            distributed training. By default, :attr:`world_size` is retrieved from the
+            current distributed group.
+        rank (int, optional): Rank of the current process within :attr:`num_replicas`.
+            By default, :attr:`rank` is retrieved from the current distributed
+            group.
+        shuffle (bool, optional): If ``True`` (default), sampler will shuffle the
+            indices.
+        seed (int, optional): random seed used to shuffle the sampler if
+            :attr:`shuffle=True`. This number should be identical across all
+            processes in the distributed group. Default: ``0``.
+        drop_last (bool, optional): if ``True``, then the sampler will drop the
+            tail of the data to make it evenly divisible across the number of
+            replicas. If ``False``, the sampler will add extra indices to make
+            the data evenly divisible across the replicas. Default: ``False``.
+
+    .. warning::
+        In distributed mode, calling the :meth:`set_epoch` method at
+        the beginning of each epoch **before** creating the :class:`DataLoader` iterator
+        is necessary to make shuffling work properly across multiple epochs. Otherwise,
+        the same ordering will be always used.
+
+    Example::
+
+        >>> # xdoctest: +SKIP
+        >>> sampler = DistributedSampler(dataset) if is_distributed else None
+        >>> loader = DataLoader(dataset, shuffle=(sampler is None),
+        ...                     sampler=sampler)
+        >>> for epoch in range(start_epoch, n_epochs):
+        ...     if is_distributed:
+        ...         sampler.set_epoch(epoch)
+        ...     train(loader)
+    """
+
+    def __init__(self, 
+                *,
+                data_conf,
+                dataset,
+                batch_size,
+                num_replicas: Optional[int] = None,
+                rank: Optional[int] = None, shuffle: bool = True,
+                seed: int = 0, drop_last: bool = False) -> None:
+        if num_replicas is None:
+            if not dist.is_available():
+                raise RuntimeError("Requires distributed package to be available")
+            num_replicas = dist.get_world_size()
+        if rank is None:
+            if not dist.is_available():
+                raise RuntimeError("Requires distributed package to be available")
+            rank = dist.get_rank()
+        if rank >= num_replicas or rank < 0:
+            raise ValueError(
+                "Invalid rank {}, rank should be in the interval"
+                " [0, {}]".format(rank, num_replicas - 1))
+        self._data_conf = data_conf
+        self._dataset = dataset
+        self._data_csv = self._dataset.csv
+        self._dataset_indices = list(range(len(self._data_csv)))
+        self._data_csv['index'] = self._dataset_indices
+        # _repeated_size is the size of the dataset multiply by batch size
+        self._repeated_size = batch_size * len(self._data_csv)
+        self._batch_size = batch_size
+        self.num_replicas = num_replicas
+        self.rank = rank
+        self.epoch = 0
+        self.drop_last = drop_last
+        # If the dataset length is evenly divisible by # of replicas, then there
+        # is no need to drop any data, since the dataset will be split equally.
+        if self.drop_last and self._repeated_size % self.num_replicas != 0:  # type: ignore[arg-type]
+            # Split to nearest available length that is evenly divisible.
+            # This is to ensure each rank receives the same amount of data when
+            # using this Sampler.
+            self.num_samples = math.ceil(
+                (self._repeated_size - self.num_replicas) / self.num_replicas  # type: ignore[arg-type]
+            )
+        else:
+            self.num_samples = math.ceil(self._repeated_size / self.num_replicas)  # type: ignore[arg-type]
+        self.total_size = self.num_samples * self.num_replicas
+        self.shuffle = shuffle
+        self.seed = seed
+
+    def __iter__(self) :
+        if self.shuffle:
+            # deterministically shuffle based on epoch and seed
+            g = torch.Generator()
+            g.manual_seed(self.seed + self.epoch)
+            indices = torch.randperm(len(self._data_csv), generator=g).tolist()  # type: ignore[arg-type]
+        else:
+            indices = list(range(len(self._data_csv)))  # type: ignore[arg-type]
+
+        # indices is expanded by self._batch_size times
+        indices = np.repeat(indices, self._batch_size)
+        
+        if not self.drop_last:
+            # add extra samples to make it evenly divisible
+            padding_size = self.total_size - len(indices)
+            if padding_size <= len(indices):
+                indices = np.concatenate((indices, indices[:padding_size]), axis=0)
+            else:
+                indices = np.concatenate((indices, np.repeat(indices, math.ceil(padding_size / len(indices)))[:padding_size]), axis=0)
+
+        else:
+            # remove tail of data to make it evenly divisible.
+            indices = indices[:self.total_size]
+        assert len(indices) == self.total_size
+
+        # subsample
+        indices = indices[self.rank:self.total_size:self.num_replicas]
+        # 
+        assert len(indices) == self.num_samples
+
+        return iter(indices)
+
+    def __len__(self) -> int:
+        return self.num_samples
+
+    def set_epoch(self, epoch: int) -> None:
+        r"""
+        Sets the epoch for this sampler. When :attr:`shuffle=True`, this ensures all replicas
+        use a different random ordering for each epoch. Otherwise, the next iteration of this
+        sampler will yield the same ordering.
+
+        Args:
+            epoch (int): Epoch number.
+        """
+        self.epoch = epoch

--- a/data/process_pdb_dataset.py
+++ b/data/process_pdb_dataset.py
@@ -80,6 +80,8 @@ def _retrieve_mmcif_files(
         if not os.path.isdir(mmcif_file_dir):
             continue
         for mmcif_file in os.listdir(mmcif_file_dir):
+            if not mmcif_file.endswith('.cif'):
+                continue
             mmcif_path = os.path.join(mmcif_file_dir, mmcif_file)
             total_num_files += 1
             if min_file_size <= os.path.getsize(mmcif_path) <= max_file_size:
@@ -123,8 +125,8 @@ def process_mmcif(
             parsed_mmcif = mmcif_parsing.parse(
                 file_id=mmcif_name, mmcif_string=f.read())
     except:
-        raise errors.MmcifParsingError(
-            f'Error parsing {mmcif_path}'
+        raise errors.FileExistsError(
+            f'Error file do not exist {mmcif_path}'
         )
     metadata['raw_path'] = mmcif_path
     if parsed_mmcif.errors:

--- a/experiments/train_se3_diffusion.py
+++ b/experiments/train_se3_diffusion.py
@@ -31,7 +31,9 @@ from collections import deque
 from datetime import datetime
 from omegaconf import DictConfig
 from omegaconf import OmegaConf
-from torch.nn.parallel import DataParallel as DP
+from torch.nn import DataParallel as DP
+from torch.nn.parallel import DistributedDataParallel as DDP
+import torch.distributed as dist
 from openfold.utils import rigid_utils as ru
 from hydra.core.hydra_config import HydraConfig
 
@@ -62,6 +64,30 @@ class Experiment:
             [str(x) for x in GPUtil.getAvailable(
                 order='memory', limit = 8)])
 
+        # Configs
+        self._conf = conf
+        self._exp_conf = conf.experiment
+        if HydraConfig.initialized() and 'num' in HydraConfig.get().job:
+            self._exp_conf.name = (
+                f'{self._exp_conf.name}_{HydraConfig.get().job.num}')
+        self._diff_conf = conf.diffuser
+        self._model_conf = conf.model
+        self._data_conf = conf.data
+        self._use_wandb = self._exp_conf.use_wandb
+        self._use_ddp = self._exp_conf.use_ddp
+        # 1. initialize ddp info if in ddp mode
+        # 2. silent rest of logger when use ddp mode
+        # 3. silent wandb logger
+        # 4. unset checkpoint path if rank is not 0 to avoid saving checkpoints and evaluation
+        if self._use_ddp :
+            torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
+            dist.init_process_group(backend='nccl')
+            self.ddp_info = self.get_ddp_info()
+            if self.ddp_info['rank'] not in [0,-1]:
+                self._log.addHandler(logging.NullHandler())
+                self._log.setLevel("ERROR")
+                self._use_wandb = False
+                self._exp_conf.ckpt_dir = None
         # Warm starting
         ckpt_model = None
         ckpt_opt = None
@@ -96,16 +122,6 @@ class Experiment:
             if 'step' in ckpt_pkl:
                 self.trained_steps = ckpt_pkl['step']
 
-        # Configs
-        self._conf = conf
-        self._exp_conf = conf.experiment
-        if HydraConfig.initialized() and 'num' in HydraConfig.get().job:
-            self._exp_conf.name = (
-                f'{self._exp_conf.name}_{HydraConfig.get().job.num}')
-        self._diff_conf = conf.diffuser
-        self._model_conf = conf.model
-        self._data_conf = conf.data
-        self._use_wandb = self._exp_conf.use_wandb
 
         # Initialize experiment objects
         self._diffuser = se3_diffuser.SE3Diffuser(self._diff_conf)
@@ -122,7 +138,7 @@ class Experiment:
         self._optimizer = torch.optim.Adam(
             self._model.parameters(), lr=self._exp_conf.learning_rate)
         if ckpt_opt is not None:
-            self._optimizer.load_state_dict(ckpt_opt, strict=True)
+            self._optimizer.load_state_dict(ckpt_opt)
 
         dt_string = datetime.now().strftime("%dD_%mM_%YY_%Hh_%Mm_%Ss")
         if self._exp_conf.ckpt_dir is not None:
@@ -135,6 +151,10 @@ class Experiment:
                 os.makedirs(ckpt_dir, exist_ok=True)
             self._exp_conf.ckpt_dir = ckpt_dir
             self._log.info(f'Checkpoints saved to: {ckpt_dir}')
+        else:
+            
+            self._log.info('Checkpoint not being saved.')
+        if self._exp_conf.eval_dir is not None :
             eval_dir = os.path.join(
                 self._exp_conf.eval_dir,
                 self._exp_conf.name,
@@ -142,8 +162,8 @@ class Experiment:
             self._exp_conf.eval_dir = eval_dir
             self._log.info(f'Evaluation saved to: {eval_dir}')
         else:
-            self._log.info('Checkpoint not being saved.')
-
+            self._exp_conf.eval_dir = os.devnull
+            self._log.info(f'Evaluation will not be saved.')
         self._aux_data_history = deque(maxlen=100)
 
     @property
@@ -157,6 +177,13 @@ class Experiment:
     @property
     def conf(self):
         return self._conf
+
+    def get_ddp_info(self):
+        local_rank = int(os.environ["LOCAL_RANK"])
+        rank = dist.get_rank()
+        world_size = dist.get_world_size()
+        node_id = rank // world_size
+        return {"node_id": node_id, "local_rank": local_rank, "rank": rank, "world_size": world_size}
 
     def create_dataset(self):
 
@@ -172,13 +199,18 @@ class Experiment:
             diffuser=self._diffuser,
             is_training=False
         )
-
-        train_sampler = pdb_data_loader.TrainSampler(
-            data_conf=self._data_conf,
-            dataset=train_dataset,
-            batch_size=self._exp_conf.batch_size,
-        )
-
+        if not self._use_ddp:
+            train_sampler = pdb_data_loader.TrainSampler(
+                data_conf=self._data_conf,
+                dataset=train_dataset,
+                batch_size=self._exp_conf.batch_size,
+            )
+        else:
+            train_sampler = pdb_data_loader.DistributedTrainSampler(
+                data_conf=self._data_conf,
+                dataset=train_dataset,
+                batch_size=self._exp_conf.batch_size,
+            )
         valid_sampler = None
 
         # Loaders
@@ -188,7 +220,7 @@ class Experiment:
             sampler=train_sampler,
             np_collate=False,
             length_batch=True,
-            batch_size=self._exp_conf.batch_size,
+            batch_size=self._exp_conf.batch_size if not self._exp_conf.use_ddp else self._exp_conf.batch_size // self.ddp_info['world_size'],
             shuffle=False,
             num_workers=num_workers,
             drop_last=False,
@@ -228,21 +260,51 @@ class Experiment:
             replica_id = 0
         if self._use_wandb and replica_id == 0:
                 self.init_wandb()
+        assert(not self._exp_conf.use_ddp or self._exp_conf.use_gpu)
 
+        # GPU mode
         if torch.cuda.is_available() and self._exp_conf.use_gpu:
-            gpu_id = self._available_gpus[replica_id]
-            device = f"cuda:{gpu_id}"
+            # single GPU mode
+            if self._exp_conf.num_gpus==1 :
+                gpu_id = self._available_gpus[replica_id]
+                device = f"cuda:{gpu_id}"
+                self._model = self.model.to(device)
+                self._log.info(f"Using device: {device}")
+            #muti gpu mode
+            elif self._exp_conf.num_gpus > 1:
+                device_ids = [
+                f"cuda:{i}" for i in self._available_gpus[:self._exp_conf.num_gpus]
+                ]
+                #DDP mode
+                if self._use_ddp :
+                    device = torch.device("cuda",self.ddp_info['local_rank'])
+                    model = self.model.to(device)
+                    self._model = DDP(model, device_ids=[self.ddp_info['local_rank']], output_device=self.ddp_info['local_rank'],find_unused_parameters=True)
+                    self._log.info(f"Multi-GPU training on GPUs in DDP mode, node_id : {self.ddp_info['node_id']}, devices: {device_ids}")
+                #DP mode
+                else:
+                    assert(len(self._available_gpus)>self._exp_conf.num_gpus,f"require {self._exp_conf.num_gpus} GPUs, but only {len(self._available_gpus)} GPUs available ")
+                    self._model = self.model.to(device)
+                    self._model = DP(self._model, device_ids=device_ids)
+                    self._log.info(f"Multi-GPU training on GPUs in DP mode: {device_ids}")
         else:
             device = 'cpu'
-        self._log.info(f"Using device: {device}")
+            self._model = self.model.to(device)
+            self._log.info(f"Using device: {device}")
 
         if self._exp_conf.num_gpus > 1:
             device_ids = [
                 f"cuda:{i}" for i in self._available_gpus[:self._exp_conf.num_gpus]
             ]
             self._log.info(f"Multi-GPU training on GPUs: {device_ids}")
-            self._model = DP(self._model, device_ids=device_ids)
-        self._model = self.model.to(device)
+            # intialize with ddp mode
+            if self._use_ddp :
+                device = torch.device("cuda",self.ddp_info['local_rank'])
+                model = self.model.to(device)
+                self._model = DDP(model, device_ids=[self.ddp_info['local_rank']], output_device=self.ddp_info['local_rank'],find_unused_parameters=True)
+            else:
+                self._model = self.model.to(device)
+                self._model = DP(self._model, device_ids=device_ids)
         self._model.train()
 
         (
@@ -619,6 +681,7 @@ class Experiment:
 
         assert final_loss.shape == (batch_size,)
         assert batch_loss_mask.shape == (batch_size,)
+        # print(f"model_out : {model_out} , aux_data : {aux_data} ,final loss : {final_loss},batch_loss_mask.sum() : {batch_loss_mask.sum()} ")
         return normalize_loss(final_loss), aux_data
 
     def _calc_trans_0(self, trans_score, trans_t, t):

--- a/experiments/utils.py
+++ b/experiments/utils.py
@@ -1,12 +1,21 @@
 """Utility functions for experiments."""
+import os
 import numpy as np
 import torch
 from typing import Optional
 import random
-
+import torch.distributed as dist
 from openfold.utils import rigid_utils
 
 Rigid = rigid_utils.Rigid
+
+
+def get_ddp_info():
+    local_rank = int(os.environ["LOCAL_RANK"])
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    node_id = rank // world_size
+    return {"node_id": node_id, "local_rank": local_rank, "rank": rank, "world_size": world_size}
 
 
 def flatten_dict(raw_dict):


### PR DESCRIPTION
Hi，i would like to provide DDP mode support for FrameDiff, and i has test it to stably run.
Here is some main change:

1.**modified Experiment class** :  
- add function get_ddp_info() to get world size,rank,local rank,node id. 
- silent wandb and logger if not rank 0 processor, also for eval_fn and svae ckpt.

2.**careat distributedSample to cooperate train sampler with torch.utils.data.distributed.DistributedSampler**

**Another important but small change:**
&nbsp;&nbsp;&nbsp;&nbsp;process_csv_row(self, processed_file_path) owns a annotattion @fn.lru_cache(maxsize=50000), which cost a huge memory, it is ok when use DP mode since this is only one dataloader(which is also quite expensive because of each dataloader worker does not share this memory cache), for DP and 10 num_worker, it can cost more than 200G memory. In DDP mode, since each GPU owns a dataset, this memory cost is multiplied by gpu_num which cant be affored. So i change it to a samller number @fn.lru_cache(maxsize=100), there is not any speed down. 

 